### PR TITLE
chore: add Kodiak config

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,0 +1,14 @@
+version = 1
+
+[merge]
+method = "squash"
+automerge_label = ["ready to merge"]
+blocking_labels = ["do not merge"]
+
+[merge.message]
+title = "pull_request_title"
+include_pr_number = true
+
+[merge.automerge_dependencies]
+versions = ["minor", "patch"]
+usernames = ["dependabot"]


### PR DESCRIPTION
## Purpose

This is an experiment to automate our PR merges with [Kodiak](https://kodiakhq.com/). This is especially handy for automatic dependency upgrades from Dependabot (though we need to fix GitHub Actions for Dependabot first). 

## Approach and changes

- Add config file for Kodiak: It will try to automatically squash merge PRs with the "ready to merge" label that pass all requirements (CI checks and review approval) using the PR title as commit message. 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
