### PR TITLE
fix: correct types for `resolveCurrencyFormat`

### DIFF
--- a/src/lib/number-format/index.ts
+++ b/src/lib/number-format/index.ts
@@ -355,6 +355,7 @@ export const resolveCurrencyFormat = resolveNumberFormatFactory(
   getCurrencyOptions,
 ) as (
   locales?: Locale | Locale[],
+  currency?: Currency,
   options?: Intl.NumberFormatOptions,
 ) => NumberFormat | null;
 

--- a/src/tests/format.spec.ts
+++ b/src/tests/format.spec.ts
@@ -50,10 +50,22 @@ describe('Format', () => {
       });
     });
 
-    it('should format as a unitless number if currency is not found', () => {
-      const actual = formatCurrency(number, 'xx-XX');
+    it('should accept a custom currency', () => {
+      const locale = 'xx-XX';
+      const currency = 'XXX';
+      const actual = formatCurrency(number, locale, currency);
       expect(actual).toBeString();
-      expect(Intl.NumberFormat).toHaveBeenCalledWith('xx-XX', {
+      expect(Intl.NumberFormat).toHaveBeenCalledWith(locale, {
+        style: 'currency',
+        currency,
+      });
+    });
+
+    it('should format as a unitless number if currency is not found', () => {
+      const locale = 'xx-XX';
+      const actual = formatCurrency(number, locale);
+      expect(actual).toBeString();
+      expect(Intl.NumberFormat).toHaveBeenCalledWith(locale, {
         style: 'decimal',
       });
     });

--- a/src/tests/formatToParts.spec.ts
+++ b/src/tests/formatToParts.spec.ts
@@ -49,5 +49,16 @@ describe('Format to parts', () => {
         currency: expect.any(String),
       });
     });
+
+    it('should accept a custom currency', () => {
+      const locale = 'xx-XX';
+      const currency = 'XXX';
+      const actual = formatCurrencyToParts(number, locale, currency);
+      expect(actual).toBeArray();
+      expect(Intl.NumberFormat).toHaveBeenCalledWith(locale, {
+        style: 'currency',
+        currency,
+      });
+    });
   });
 });

--- a/src/tests/resolveFormat.spec.ts
+++ b/src/tests/resolveFormat.spec.ts
@@ -37,5 +37,16 @@ describe('Resolve format', () => {
         currency: expect.any(String),
       });
     });
+
+    it('should accept a custom currency', () => {
+      const locale = 'xx-XX';
+      const currency = 'XXX';
+      const actual = resolveCurrencyFormat(locale, currency);
+      expect(actual).toBeObject();
+      expect(Intl.NumberFormat).toHaveBeenCalledWith(locale, {
+        style: 'currency',
+        currency,
+      });
+    });
   });
 });


### PR DESCRIPTION
Addresses https://github.com/sumup-oss/circuit-ui/pull/1843#issuecomment-1324008737.

## Purpose

When improving the types of the function parameters in https://github.com/sumup-oss/intl-js/pull/126, I mistakenly omitted the type for the `currency` parameter in the `resolveCurrencyFormat` function.

## Approach and changes

- Re-add the missing type
- Add tests to avoid regressions

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
