### PR TITLE
feat: Update Croatian currency to EUR

### DIFF
--- a/src/data/currencies.ts
+++ b/src/data/currencies.ts
@@ -213,7 +213,7 @@ export const CURRENCIES: { [country: string]: Currency } = {
   // Honduras
   HN: 'HNL',
   // Croatia (Hrvatska)
-  HR: 'HRK',
+  HR: 'EUR',
   // Haiti
   HT: 'HTG',
   // Hungary


### PR DESCRIPTION
Croatia joined the eurozone on January 1, 2023: https://www.ecb.europa.eu/euro/changeover/croatia/html/index.en.html