### PR TITLE
Format COP and HUF currency values without decimals

### DIFF
--- a/.changeset/chatty-pants-tan.md
+++ b/.changeset/chatty-pants-tan.md
@@ -1,0 +1,5 @@
+---
+'@sumup/intl': minor
+---
+
+Added exceptions for the COP and HUF currencies to be formatted without decimals. While these currencies support decimals under the ISO standard, the decimals are not used in everyday life.

--- a/src/data/currencies.ts
+++ b/src/data/currencies.ts
@@ -513,3 +513,9 @@ export const CURRENCIES: { [country: string]: Currency } = {
   // Zimbabwe
   ZW: 'ZWD',
 };
+
+/**
+ * An array of currencies that support decimals according to the ISO standard
+ * but don't use decimals in everyday life.
+ */
+export const CURRENCIES_WITHOUT_DECIMALS = ['COP', 'HUF'];

--- a/src/lib/number-format/currencies.ts
+++ b/src/lib/number-format/currencies.ts
@@ -16,7 +16,7 @@
 /* eslint-disable no-continue */
 
 import type { Locale, Currency, NumericOptions } from '../../types';
-import { CURRENCIES } from '../../data/currencies';
+import { CURRENCIES, CURRENCIES_WITHOUT_DECIMALS } from '../../data/currencies';
 
 import { resolveLocale } from './intl';
 
@@ -71,8 +71,24 @@ export function getCurrencyOptions(
   const finalCurrency = currency || resolveCurrency(locales);
 
   if (!finalCurrency) {
-    return { ...options, style: 'decimal' };
+    return {
+      ...options,
+      style: 'decimal',
+    };
   }
 
-  return { ...options, style: 'currency', currency: finalCurrency };
+  if (CURRENCIES_WITHOUT_DECIMALS.includes(finalCurrency)) {
+    return {
+      ...options,
+      style: 'currency',
+      currency: finalCurrency,
+      minimumFractionDigits: 0,
+    };
+  }
+
+  return {
+    ...options,
+    style: 'currency',
+    currency: finalCurrency,
+  };
 }

--- a/src/lib/number-format/index.ts
+++ b/src/lib/number-format/index.ts
@@ -91,6 +91,8 @@ export const format = formatNumber;
  * In runtimes that don't support the `Intl.NumberFormat` API, the currency is
  * formatted using the `Number.toLocaleString` API.
  *
+ * The COP and HUF currencies are formatted without decimals.
+ *
  * @category Currency
  */
 export const formatCurrency = formatNumberFactory(getCurrencyOptions) as (
@@ -209,6 +211,8 @@ export const formatToParts = formatNumberToParts;
  * @remarks
  * In runtimes that don't support the `Intl.NumberFormat.formatToParts` API,
  * the currency is localized and returned as a single integer part.
+ *
+ * The COP and HUF currencies are formatted without decimals.
  *
  * @category Currency
  */
@@ -379,6 +383,8 @@ export const resolveFormat = resolveNumberFormat;
  *
  * In runtimes that don't support the `Intl.NumberFormat.resolvedOptions` API,
  * `null` is returned.
+ *
+ * The COP and HUF currencies are formatted without decimals.
  *
  * @category Currency
  */

--- a/src/lib/number-format/tests/format-to-parts.spec.ts
+++ b/src/lib/number-format/tests/format-to-parts.spec.ts
@@ -14,6 +14,7 @@
  */
 
 import { formatNumberToParts, formatCurrencyToParts } from '..';
+import { CURRENCIES_WITHOUT_DECIMALS } from '../../../data/currencies';
 
 import { locales, number } from './shared';
 
@@ -46,11 +47,32 @@ describe('Currency values', () => {
     it.each(locales)('should format a currency for %o', (locale) => {
       const actual = formatCurrencyToParts(number, locale);
       expect(actual).toBeArray();
-      expect(Intl.NumberFormat).toHaveBeenCalledWith(locale, {
-        style: 'currency',
-        currency: expect.any(String),
-      });
+
+      expect(Intl.NumberFormat).toHaveBeenCalledWith(
+        locale,
+        expect.objectContaining({
+          style: 'currency',
+          currency: expect.any(String),
+        }),
+      );
     });
+
+    it.each(CURRENCIES_WITHOUT_DECIMALS)(
+      'should format the %o currency without decimals',
+      (currency) => {
+        const actual = formatCurrencyToParts(number, undefined, currency);
+        expect(actual).toBeArray();
+
+        expect(Intl.NumberFormat).toHaveBeenCalledWith(
+          undefined,
+          expect.objectContaining({
+            style: 'currency',
+            currency,
+            minimumFractionDigits: 0,
+          }),
+        );
+      },
+    );
 
     it('should accept a custom currency', () => {
       const locale = 'xx-XX';

--- a/src/lib/number-format/tests/format.spec.ts
+++ b/src/lib/number-format/tests/format.spec.ts
@@ -14,6 +14,7 @@
  */
 
 import { formatNumber, formatCurrency } from '..';
+import { CURRENCIES_WITHOUT_DECIMALS } from '../../../data/currencies';
 
 import { locales, number } from './shared';
 
@@ -46,11 +47,31 @@ describe('Currency values', () => {
     it.each(locales)('should format a currency for %o', (locale) => {
       const actual = formatCurrency(number, locale);
       expect(actual).toBeString();
-      expect(Intl.NumberFormat).toHaveBeenCalledWith(locale, {
-        style: 'currency',
-        currency: expect.any(String),
-      });
+      expect(Intl.NumberFormat).toHaveBeenCalledWith(
+        locale,
+        expect.objectContaining({
+          style: 'currency',
+          currency: expect.any(String),
+        }),
+      );
     });
+
+    it.each(CURRENCIES_WITHOUT_DECIMALS)(
+      'should format the %o currency without decimals',
+      (currency) => {
+        const actual = formatCurrency(number, undefined, currency);
+        expect(actual).toBeString();
+
+        expect(Intl.NumberFormat).toHaveBeenCalledWith(
+          undefined,
+          expect.objectContaining({
+            style: 'currency',
+            currency,
+            minimumFractionDigits: 0,
+          }),
+        );
+      },
+    );
 
     it('should accept a custom currency', () => {
       const locale = 'xx-XX';

--- a/src/lib/number-format/tests/resolve-format.spec.ts
+++ b/src/lib/number-format/tests/resolve-format.spec.ts
@@ -14,6 +14,7 @@
  */
 
 import { resolveNumberFormat, resolveCurrencyFormat } from '..';
+import { CURRENCIES_WITHOUT_DECIMALS } from '../../../data/currencies';
 
 import { locales } from './shared';
 
@@ -41,11 +42,30 @@ describe('Currency values', () => {
     it.each(locales)('should get the currency format for %o', (locale) => {
       const actual = resolveCurrencyFormat(locale);
       expect(actual).toBeObject();
-      expect(Intl.NumberFormat).toHaveBeenCalledWith(locale, {
-        style: 'currency',
-        currency: expect.any(String),
-      });
+      expect(Intl.NumberFormat).toHaveBeenCalledWith(
+        locale,
+        expect.objectContaining({
+          style: 'currency',
+          currency: expect.any(String),
+        }),
+      );
     });
+
+    it.each(CURRENCIES_WITHOUT_DECIMALS)(
+      'should get the %o currency format without decimals',
+      (currency) => {
+        const actual = resolveCurrencyFormat(undefined, currency);
+        expect(actual).toBeObject();
+        expect(Intl.NumberFormat).toHaveBeenCalledWith(
+          undefined,
+          expect.objectContaining({
+            style: 'currency',
+            currency,
+            minimumFractionDigits: 0,
+          }),
+        );
+      },
+    );
 
     it('should include additional options', () => {
       const locale = 'en-US';


### PR DESCRIPTION
## Purpose

While the COP and HUF currencies support decimals under the ISO standard, the decimals are not used in everyday life.

## Approach and changes

- Add exceptions for the COP and HUF currencies to be formatted without decimals

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
