### PR TITLE
Address breaking changes in typedoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Format 🔢 numbers, 💱 currency values, 📅 dates, and 🕘 times for any lo
 - [Introduction](#introduction)
 - [Installation](#installation)
 - [Usage](#usage)
-- [API reference](https://github.com/sumup-oss/intl-js/wiki/Exports)
+- [API reference](https://github.com/sumup-oss/intl-js/wiki)
 - [Code of Conduct](#code-of-conduct)
 - [About SumUp](#about-sumup)
 
@@ -60,31 +60,31 @@ Each type of data can be formatted with three increasingly advanced functions:
 
 ### Number Functions
 
-- [formatNumber](https://github.com/sumup-oss/intl-js/wiki/Exports#formatnumber)
-- [formatNumberToParts](https://github.com/sumup-oss/intl-js/wiki/Exports#formatnumbertoparts)
-- [resolveNumberFormat](https://github.com/sumup-oss/intl-js/wiki/Exports#resolvenumberformat)
+- [formatNumber](https://github.com/sumup-oss/intl-js/wiki/Function.formatnumber)
+- [formatNumberToParts](https://github.com/sumup-oss/intl-js/wiki/Function.formatnumbertoparts)
+- [resolveNumberFormat](https://github.com/sumup-oss/intl-js/wiki/Function.resolvenumberformat)
 
 ### Currency Functions
 
-- [formatCurrency](https://github.com/sumup-oss/intl-js/wiki/Exports#formatcurrency)
-- [formatCurrencyToParts](https://github.com/sumup-oss/intl-js/wiki/Exports#formatcurrencytoparts)
-- [resolveCurrencyFormat](https://github.com/sumup-oss/intl-js/wiki/Exports#resolvecurrencyformat)
+- [formatCurrency](https://github.com/sumup-oss/intl-js/wiki/Function.formatcurrency)
+- [formatCurrencyToParts](https://github.com/sumup-oss/intl-js/wiki/Function.formatcurrencytoparts)
+- [resolveCurrencyFormat](https://github.com/sumup-oss/intl-js/wiki/Function.resolvecurrencyformat)
 
 ### Date & Time Functions
 
-- [formatDate](https://github.com/sumup-oss/intl-js/wiki/Exports#formatdate)
-- [formatTime](https://github.com/sumup-oss/intl-js/wiki/Exports#formattime)
-- [formatDateTime](https://github.com/sumup-oss/intl-js/wiki/Exports#formatdatetime)
-- [formatDateTimeToParts](https://github.com/sumup-oss/intl-js/wiki/Exports#formatdatetimetoparts)
-- [resolveDateTimeFormat](https://github.com/sumup-oss/intl-js/wiki/Exports#resolvedatetimeformat)
+- [formatDate](https://github.com/sumup-oss/intl-js/wiki/Function.formatdate)
+- [formatTime](https://github.com/sumup-oss/intl-js/wiki/Function.formattime)
+- [formatDateTime](https://github.com/sumup-oss/intl-js/wiki/Function.formatdatetime)
+- [formatDateTimeToParts](https://github.com/sumup-oss/intl-js/wiki/Function.formatdatetimetoparts)
+- [resolveDateTimeFormat](https://github.com/sumup-oss/intl-js/wiki/Function.resolvedatetimeformat)
 
 ### Variables
 
-- [CURRENCIES](https://github.com/sumup-oss/intl-js/wiki/Exports#currencies)
-- [isNumberFormatSupported](https://github.com/sumup-oss/intl-js/wiki/Exports#isnumberformatsupported)
-- [isNumberFormatToPartsSupported](https://github.com/sumup-oss/intl-js/wiki/Exports#isnumberformattopartssupported)
-- [isDateTimeFormatSupported](https://github.com/sumup-oss/intl-js/wiki/Exports#isdatetimeformatsupported)
-- [isDateTimeFormatToPartsSupported](https://github.com/sumup-oss/intl-js/wiki/Exports#isdatetimeformattopartssupported)
+- [CURRENCIES](https://github.com/sumup-oss/intl-js/wiki/Variable.currencies)
+- [isNumberFormatSupported](https://github.com/sumup-oss/intl-js/wiki/Variable.isnumberformatsupported)
+- [isNumberFormatToPartsSupported](https://github.com/sumup-oss/intl-js/wiki/Variable.isnumberformattopartssupported)
+- [isDateTimeFormatSupported](https://github.com/sumup-oss/intl-js/wiki/Variable.isdatetimeformatsupported)
+- [isDateTimeFormatToPartsSupported](https://github.com/sumup-oss/intl-js/wiki/Variable.isdatetimeformattopartssupported)
 
 ## Code of Conduct
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,13 @@
 {
+  "$schema": "https://typedoc-plugin-markdown.org/schema.json",
   "entryPoints": ["src/index.ts"],
   "sort": ["source-order"],
   "categoryOrder": ["Number", "Currency", "Date & Time", "*"],
-  "plugin": ["typedoc-plugin-markdown", "typedoc-github-wiki-theme"]
+  "plugin": ["typedoc-plugin-markdown", "typedoc-github-wiki-theme"],
+  "readme": "none",
+  "enumMembersFormat": "table",
+  "parametersFormat": "table",
+  "propertiesFormat": "table",
+  "typeDeclarationFormat": "table",
+  "indexFormat": "table"
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -9,5 +9,8 @@
   "parametersFormat": "table",
   "propertiesFormat": "table",
   "typeDeclarationFormat": "table",
-  "indexFormat": "table"
+  "indexFormat": "table",
+  "sidebar": {
+    "autoConfiguration": false
+  }
 }


### PR DESCRIPTION
Relates to #229 and #234.

## Purpose

The recent `typedoc-plugin-markdown` and `typedoc-github-wiki-theme` upgrades changed the structure of the generated GitHub wiki pages. 

## Approach and changes

- Adjust typedoc configuration
- Fix links in README

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
