### PR TITLE
Rename package scope from @sumup to @sumup-oss

### DIFF
--- a/.changeset/eight-ties-fetch.md
+++ b/.changeset/eight-ties-fetch.md
@@ -1,5 +1,5 @@
 ---
-'@sumup/intl': major
+'@sumup-oss/intl': major
 ---
 
 Added support for Temporal objects to the date and time formatting functions. The [`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill) package is now a required peer dependency.

--- a/.changeset/loud-bugs-raise.md
+++ b/.changeset/loud-bugs-raise.md
@@ -1,0 +1,10 @@
+---
+'@sumup-oss/intl': major
+---
+
+Renamed the package scope from `@sumup` to `@sumup-oss`. Replace `@sumup/intl` with `@sumup-oss/intl` in your `package.json` file, then update all imports:
+
+```diff
+-import { formatNumber } from '@sumup/intl';
++import { formatNumber } from '@sumup-oss/intl';
+```

--- a/.changeset/nasty-years-wonder.md
+++ b/.changeset/nasty-years-wonder.md
@@ -1,5 +1,5 @@
 ---
-'@sumup/intl': major
+'@sumup-oss/intl': major
 ---
 
 Removed the deprecated `format`, `formatToParts`, `resolveFormat`, and `isIntlSupported` exports. Use the explicitly named `formatNumber`, `formatNumberToParts`, `resolveNumberFormat`, and `isNumberFormatSupported` exports instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @sumup/intl
+# @sumup-oss/intl
 
 ## 1.6.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,11 @@ Make sure that you use Node v20.14 _exactly_, otherwise, the unit tests will pro
 
 ## Release process
 
-`@sumup/intl` follows semantic versioning. In short, this means we use patch versions for bugfixes, minor versions for new features, and major versions for breaking changes.
+`@sumup-oss/intl` follows semantic versioning. In short, this means we use patch versions for bugfixes, minor versions for new features, and major versions for breaking changes.
 
 ### Changesets
 
-`@sumup/intl` uses [changesets](https://github.com/atlassian/changesets) to do versioning. A changeset is a piece of information about changes made in a branch or commit. It holds three bits of information:
+`@sumup-oss/intl` uses [changesets](https://github.com/atlassian/changesets) to do versioning. A changeset is a piece of information about changes made in a branch or commit. It holds three bits of information:
 
 - What needs to be released
 - What version the packages should be released at (using a [semver bump type](https://semver.org/))
@@ -62,7 +62,7 @@ We have a couple of special branches that are used for stable releases and [pre-
 To install the most recent version from a release channel in your project, run:
 
 ```sh
-npm install --dev @sumup/intl@<release-channel>
+npm install --dev @sumup-oss/intl@<release-channel>
 ```
 
 #### Pre-releases

--- a/README.md
+++ b/README.md
@@ -20,33 +20,33 @@ Format 🔢 numbers, 💱 currency values, 📅 dates, and 🕘 times for any lo
 
 ## Introduction
 
-`@sumup/intl` is a light abstraction layer on top of the [ECMAScript Internationalization API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl). In addition to a simplified API, it offers the following benefits:
+`@sumup-oss/intl` is a light abstraction layer on top of the [ECMAScript Internationalization API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl). In addition to a simplified API, it offers the following benefits:
 
 ### Performance
 
-Creating instances of `Intl.*` formatters is an [expensive operation](https://blog.david-reess.de/posts/hBEx9w-on-number-formatting-and-performance). `@sumup/intl` solves this by [memoizing](https://github.com/formatjs/intl-format-cache) the `Intl` formatters with a cache key based on the arguments passed to the constructor.
+Creating instances of `Intl.*` formatters is an [expensive operation](https://blog.david-reess.de/posts/hBEx9w-on-number-formatting-and-performance). `@sumup-oss/intl` solves this by [memoizing](https://github.com/formatjs/intl-format-cache) the `Intl` formatters with a cache key based on the arguments passed to the constructor.
 
 ### Compatibility
 
-`@sumup/intl` works in [modern browsers](https://caniuse.com/mdn-javascript_builtins_intl_numberformat_numberformat,mdn-javascript_builtins_intl_datetimeformat_datetimeformat) as well as server runtimes with support for the `Intl` APIs (such as Node 10+[^1]). When the `Intl` APIs aren't (fully) available, `@sumup/intl` tries to gracefully degrade. Please refer to the [API reference](#api-reference) to learn how certain functions behave when the runtime doesn't support the necessary APIs. If you need to support legacy browsers, consider including [polyfills](https://formatjs.io/docs/polyfills/).
+`@sumup-oss/intl` works in [modern browsers](https://caniuse.com/mdn-javascript_builtins_intl_numberformat_numberformat,mdn-javascript_builtins_intl_datetimeformat_datetimeformat) as well as server runtimes with support for the `Intl` APIs (such as Node 10+[^1]). When the `Intl` APIs aren't (fully) available, `@sumup-oss/intl` tries to gracefully degrade. Please refer to the [API reference](#api-reference) to learn how certain functions behave when the runtime doesn't support the necessary APIs. If you need to support legacy browsers, consider including [polyfills](https://formatjs.io/docs/polyfills/).
 
-`@sumup/intl` integrates [`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill) to support formatting [`Temporal`](https://github.com/tc39/proposal-temporal) date-time objects.
+`@sumup-oss/intl` integrates [`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill) to support formatting [`Temporal`](https://github.com/tc39/proposal-temporal) date-time objects.
 
 [^1]: [Node](https://nodejs.org/en/) supports the `Intl` APIs since v8, however, it includes only the English localizations up to v12. Node v13 and above support all locales. If you're unable to use Node v13+, you can either include [polyfills](https://formatjs.io/docs/polyfills/) or use a [custom Node build](https://nodejs.org/docs/latest-v8.x/api/intl.html#intl_options_for_building_node_js).
 
 ## Installation
 
-[`@sumup/intl`](https://www.npmjs.com/package/@sumup/intl) can be installed as a dependency via the [npm](https://www.npmjs.com) package manager. The [`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill) package is a required peer dependency.
+[`@sumup-oss/intl`](https://www.npmjs.com/package/@sumup-oss/intl) can be installed as a dependency via the [npm](https://www.npmjs.com) package manager. The [`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill) package is a required peer dependency.
 
 ```sh
-npm install @sumup/intl temporal-polyfill
+npm install @sumup-oss/intl temporal-polyfill
 ```
 
-`@sumup/intl` requires Node v10+.
+`@sumup-oss/intl` requires Node v10+.
 
 ## Usage
 
-The functions exported by `@sumup/intl` share a similar interface such as the common [`locales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument), [`options`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#options_argument), and [`currency`](https://en.wikipedia.org/wiki/ISO_4217) arguments. These are passed on almost unchanged to the [`Intl.*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#constructor_properties) constructors and thus support the same values. If the `locales` argument is not provided or is undefined, the runtime's default locale is used. Please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) for more details.
+The functions exported by `@sumup-oss/intl` share a similar interface such as the common [`locales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument), [`options`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#options_argument), and [`currency`](https://en.wikipedia.org/wiki/ISO_4217) arguments. These are passed on almost unchanged to the [`Intl.*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#constructor_properties) constructors and thus support the same values. If the `locales` argument is not provided or is undefined, the runtime's default locale is used. Please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) for more details.
 
 Each type of data can be formatted with three increasingly advanced functions:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@sumup/intl",
+  "name": "@sumup-oss/intl",
   "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@sumup/intl",
+      "name": "@sumup-oss/intl",
       "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sumup/intl",
+  "name": "@sumup-oss/intl",
   "version": "1.6.0",
   "description": "Format numbers, currency values, dates, and times for any locale with the ECMAScript Internationalization API",
   "repository": "git@github.com:sumup-oss/intl-js.git",

--- a/src/lib/date-time-format/index.ts
+++ b/src/lib/date-time-format/index.ts
@@ -31,7 +31,7 @@ export { isDateTimeFormatSupported, isDateTimeFormatToPartsSupported };
  * and [time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#timestyle) styles.
  *
  * @example
- * import { formatDateTime } from '@sumup/intl';
+ * import { formatDateTime } from '@sumup-oss/intl';
  *
  * formatDateTime(new Date(2000, 1, 1), 'de-DE'); // '1.2.2000'
  * formatDateTime(new Date(2000, 1, 1), ['ban', 'id']); // '1/2/2000'
@@ -59,7 +59,7 @@ export const formatDateTime = formatDateTimeFactory();
  * [date styles](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#datestyle).
  *
  * @example
- * import { formatDate } from '@sumup/intl';
+ * import { formatDate } from '@sumup-oss/intl';
  *
  * const date = new Date(2000, 1, 1);
  * const locale = 'en-GB';
@@ -91,7 +91,7 @@ export function formatDate(
  * [time styles](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#datestyle).
  *
  * @example
- * import { formatTime } from '@sumup/intl';
+ * import { formatTime } from '@sumup-oss/intl';
  *
  * const time = new Date(2000, 1, 1, 9, 55);
  * const locale = 'en-GB';
@@ -166,7 +166,7 @@ function formatDateTimeFactory(): (
  * and [time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#timestyle) styles.
  *
  * @example
- * import { formatDateTimeToParts } from '@sumup/intl';
+ * import { formatDateTimeToParts } from '@sumup-oss/intl';
  *
  * const time = new Date(2000, 1, 1, 9, 55);
  *
@@ -232,7 +232,7 @@ function formatDateTimeToPartsFactory(): (
  * Resolves the locale and collation options that are used to format a `Date`.
  *
  * @example
- * import { resolveDateTimeFormat } from '@sumup/intl';
+ * import { resolveDateTimeFormat } from '@sumup-oss/intl';
  *
  * resolveDateTimeFormat();
  * // {

--- a/src/lib/number-format/index.ts
+++ b/src/lib/number-format/index.ts
@@ -43,7 +43,7 @@ type GetOptions = (
  * and [notations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat#Using_notation).
  *
  * @example
- * import { formatNumber } from '@sumup/intl';
+ * import { formatNumber } from '@sumup-oss/intl';
  *
  * formatNumber(12345.67, 'de-DE'); // '12.345,67'
  * formatNumber(-0.89, ['ban', 'id']); // '-0,89'
@@ -70,7 +70,7 @@ export const formatNumber = formatNumberFactory(getNumberOptions) as (
  * with support for various [notations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat#Using_notation).
  *
  * @example
- * import { formatCurrency } from '@sumup/intl';
+ * import { formatCurrency } from '@sumup-oss/intl';
  *
  * formatCurrency(12345.67, 'de-DE'); // '12.345,67 €'
  * formatCurrency(89, 'ja-JP', 'JPY'); // '￥89'
@@ -112,7 +112,7 @@ function formatNumberFactory<T extends GetOptions>(
  * and [notations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat#Using_notation).
  *
  * @example
- * import { formatNumberToParts } from '@sumup/intl';
+ * import { formatNumberToParts } from '@sumup-oss/intl';
  *
  * formatNumberToParts(12345.67, 'de-DE');
  * // [
@@ -162,7 +162,7 @@ export const formatNumberToParts = formatNumberToPartsFactory(
  * with support for various [notations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat#Using_notation).
  *
  * @example
- * import { formatCurrencyToParts } from '@sumup/intl';
+ * import { formatCurrencyToParts } from '@sumup-oss/intl';
  *
  * formatCurrencyToParts(12345.67, 'de-DE');
  * // [
@@ -230,7 +230,7 @@ function formatNumberToPartsFactory<T extends GetOptions>(
  * Resolves the locale and collation options that are used to format a number.
  *
  * @example
- * import { resolveNumberFormat } from '@sumup/intl';
+ * import { resolveNumberFormat } from '@sumup-oss/intl';
  *
  * resolveNumberFormat();
  * // {
@@ -300,7 +300,7 @@ export const resolveNumberFormat = resolveNumberFormatFactory(
  * in the country's official currency.
  *
  * @example
- * import { resolveCurrencyFormat } from '@sumup/intl';
+ * import { resolveCurrencyFormat } from '@sumup-oss/intl';
  *
  * resolveCurrencyFormat();
  * // {


### PR DESCRIPTION
## Purpose

SumUp's private and public open-source packages all use the `@sumup` scope. This causes conflicts when installing public packages alongside private ones that require authentication and are hosted on a different registry. Users have had to use direct tarball URLs for public packages to work around these conflicts, preventing automated updates using tools like Dependabot.

## Approach and changes

- Rename the package scope from `@sumup` to `@sumup-oss`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
