### PR TITLE
Remove deprecated exports

### DIFF
--- a/.changeset/nasty-years-wonder.md
+++ b/.changeset/nasty-years-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sumup/intl': major
+---
+
+Removed the deprecated `format`, `formatToParts`, `resolveFormat`, and `isIntlSupported` exports. Use the explicitly named `formatNumber`, `formatNumberToParts`, `resolveNumberFormat`, and `isNumberFormatSupported` exports instead.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,18 +14,14 @@
  */
 
 export {
-  format,
   formatNumber,
   formatCurrency,
-  formatToParts,
   formatNumberToParts,
   formatCurrencyToParts,
-  resolveFormat,
   resolveNumberFormat,
   resolveCurrencyFormat,
   isNumberFormatSupported,
   isNumberFormatToPartsSupported,
-  isIntlSupported,
 } from './lib/number-format';
 export {
   formatDate,

--- a/src/lib/number-format/index.ts
+++ b/src/lib/number-format/index.ts
@@ -22,7 +22,6 @@ import type {
 import { findIndex } from '../find-index';
 
 import {
-  isIntlSupported,
   isNumberFormatSupported,
   isNumberFormatToPartsSupported,
   getNumberFormat,
@@ -30,11 +29,7 @@ import {
 import { getNumberOptions } from './numbers';
 import { getCurrencyOptions } from './currencies';
 
-export {
-  isIntlSupported,
-  isNumberFormatSupported,
-  isNumberFormatToPartsSupported,
-};
+export { isNumberFormatSupported, isNumberFormatToPartsSupported };
 
 type GetOptions = (
   locales: Locale | Locale[],
@@ -69,12 +64,6 @@ export const formatNumber = formatNumberFactory(getNumberOptions) as (
   locales?: Locale | Locale[],
   options?: Intl.NumberFormatOptions,
 ) => string;
-
-/**
- * @deprecated Use {@link formatNumber} instead.
- * @hidden
- */
-export const format = formatNumber;
 
 /**
  * Formats a number in the country's official currency
@@ -166,12 +155,6 @@ export const formatNumberToParts = formatNumberToPartsFactory(
   locales?: Locale | Locale[],
   options?: Intl.NumberFormatOptions,
 ) => Intl.NumberFormatPart[];
-
-/**
- * @deprecated Use {@link formatNumberToParts} instead.
- * @hidden
- */
-export const formatToParts = formatNumberToParts;
 
 /* eslint-disable no-irregular-whitespace */
 /**
@@ -311,12 +294,6 @@ export const resolveNumberFormat = resolveNumberFormatFactory(
   locales?: Locale | Locale[],
   options?: Intl.NumberFormatOptions,
 ) => NumberFormat | null;
-
-/**
- * @deprecated Use {@link resolveNumberFormat} instead.
- * @hidden
- */
-export const resolveFormat = resolveNumberFormat;
 
 /**
  * Resolves the locale and collation options that are used to format a number

--- a/src/lib/number-format/intl.ts
+++ b/src/lib/number-format/intl.ts
@@ -44,12 +44,6 @@ export const isNumberFormatToPartsSupported = (() => {
   }
 })();
 
-/**
- * @deprecated Use {@link isNumberFormatSupported} instead.
- * @hidden
- */
-export const isIntlSupported = isNumberFormatSupported;
-
 export const getNumberFormat = memoizeFormatConstructor(Intl.NumberFormat) as (
   locales?: Locale | Locale[],
   options?: Intl.NumberFormatOptions,


### PR DESCRIPTION
Relates to #126.

## Approach and changes

- Removed the deprecated `format`, `formatToParts`, `resolveFormat`, and `isIntlSupported` exports. Use the explicitly named `formatNumber`, `formatNumberToParts`, `resolveNumberFormat`, and `isNumberFormatSupported` exports instead.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
