### PR TITLE
Remove `intl-format-cache` dependency

### DIFF
--- a/.changeset/sharp-deers-return.md
+++ b/.changeset/sharp-deers-return.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/intl': patch
+---
+
+Removed the `intl-format-cache` dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "@sumup-oss/intl",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sumup-oss/intl",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "intl-format-cache": "^4.2.27"
-      },
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.5",
@@ -29,7 +26,7 @@
         "vitest": "^2.0.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
         "temporal-polyfill": "0.2.x"
@@ -7051,11 +7048,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/intl-format-cache": {
-      "version": "4.3.1",
-      "resolved": "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.3.1.tgz",
-      "integrity": "sha1-SE0xqYchYebAITk0myWaYimt43c= sha512-OEUYNA7D06agqPOYhbTkl0T8HA3QKSuwWh1HiClEnpd9vw7N+3XsQt5iZ0GUEchp5CW1fQk/tary+NsbF3yQ1Q=="
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
@@ -18999,11 +18991,6 @@
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       }
-    },
-    "intl-format-cache": {
-      "version": "4.3.1",
-      "resolved": "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.3.1.tgz",
-      "integrity": "sha1-SE0xqYchYebAITk0myWaYimt43c= sha512-OEUYNA7D06agqPOYhbTkl0T8HA3QKSuwWh1HiClEnpd9vw7N+3XsQt5iZ0GUEchp5CW1fQk/tary+NsbF3yQ1Q=="
     },
     "is-arguments": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
   "engines": {
     "node": ">=18"
   },
-  "dependencies": {
-    "intl-format-cache": "^4.2.27"
-  },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.5",

--- a/src/lib/date-time-format/intl.ts
+++ b/src/lib/date-time-format/intl.ts
@@ -14,9 +14,9 @@
  */
 
 import { Intl as IntlWithTemporal } from 'temporal-polyfill';
-import memoizeFormatConstructor from 'intl-format-cache';
 
 import { Locale } from '../../types/index.js';
+import { memoize } from '../memoize.js';
 
 /**
  * Whether the `Intl` and `Intl.DateTimeFormat` APIs
@@ -61,10 +61,7 @@ export const isDateTimeStyleSupported = (() => {
   }
 })();
 
-// @ts-expect-error intl-format-cache is bundled in a non-standard way.
-export const getDateTimeFormat = memoizeFormatConstructor(
-  IntlWithTemporal.DateTimeFormat,
-) as (
+export const getDateTimeFormat = memoize(IntlWithTemporal.DateTimeFormat) as (
   locales?: Locale | Locale[],
   options?: Intl.DateTimeFormatOptions,
 ) => IntlWithTemporal.DateTimeFormat;

--- a/src/lib/memoize.ts
+++ b/src/lib/memoize.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T> = new (...args: any[]) => T;
+
+export function memoize<
+  Format,
+  FormatConstructor extends Constructor<Format>,
+  Args extends ConstructorParameters<FormatConstructor>,
+>(IntlFormatConstructor: FormatConstructor) {
+  const cache = new Map<string, Format>();
+
+  return (...args: Args): Format => {
+    const cacheKey = getCacheKey(args);
+    if (!cacheKey) {
+      return new IntlFormatConstructor(...args);
+    }
+
+    const cachedFormat = cache.get(cacheKey);
+
+    if (cachedFormat) {
+      return cachedFormat;
+    }
+
+    const format = new IntlFormatConstructor(...args);
+
+    cache.set(cacheKey, format);
+
+    return format;
+  };
+}
+
+function getCacheKey(inputs: unknown[]) {
+  return JSON.stringify(
+    inputs.map((input) =>
+      isObject(input) ? sortObjectProperties(input) : input,
+    ),
+  );
+}
+
+function isObject<T extends Record<string, unknown>>(
+  value: unknown,
+): value is T {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function sortObjectProperties(obj: Record<string, unknown>) {
+  return Object.keys(obj)
+    .sort()
+    .map((key) => [key, obj[key]]);
+}

--- a/src/lib/number-format/intl.ts
+++ b/src/lib/number-format/intl.ts
@@ -13,9 +13,8 @@
  * limitations under the License.
  */
 
-import memoizeFormatConstructor from 'intl-format-cache';
-
 import type { Locale } from '../../types/index.js';
+import { memoize } from '../memoize.js';
 
 /**
  * Whether the `Intl` and `Intl.NumberFormat` APIs
@@ -44,8 +43,7 @@ export const isNumberFormatToPartsSupported = (() => {
   }
 })();
 
-// @ts-expect-error intl-format-cache is bundled in a non-standard way.
-export const getNumberFormat = memoizeFormatConstructor(Intl.NumberFormat) as (
+export const getNumberFormat = memoize(Intl.NumberFormat) as (
   locales?: Locale | Locale[],
   options?: Intl.NumberFormatOptions,
 ) => Intl.NumberFormat;


### PR DESCRIPTION
## Purpose

The `intl-format-cache` is unmaintained and incompatible with ES modules due to its bundling.

## Approach and changes

- Write a custom memoize function inspired by `intl-format-cache`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
