### PR TITLE
Declare support for temporal-polyfill v0.3.0

### DIFF
--- a/.changeset/shaky-spiders-love.md
+++ b/.changeset/shaky-spiders-love.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/intl': patch
+---
+
+Widened the allowed version range for the `temporal-polyfill` peer dependency which recently added support the March 2025 version of the Temporal spec.

--- a/.changeset/shaky-spiders-love.md
+++ b/.changeset/shaky-spiders-love.md
@@ -2,4 +2,4 @@
 '@sumup-oss/intl': patch
 ---
 
-Widened the allowed version range for the `temporal-polyfill` peer dependency which recently added support the March 2025 version of the Temporal spec.
+Widened the allowed version range for the `temporal-polyfill` peer dependency which recently added support for the March 2025 version of the Temporal spec.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "jest-extended": "^4.0.2",
         "license-checker": "^25.0.1",
-        "temporal-polyfill": "^0.3.0-beta",
+        "temporal-polyfill": "^0.3.0-beta.1",
         "typedoc": "^0.27.2",
         "typedoc-github-wiki-theme": "^2.1.0",
         "typedoc-plugin-markdown": "^4.3.1",
@@ -12399,9 +12399,9 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.3.0-beta",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0-beta.tgz",
-      "integrity": "sha512-1NJXDbRjvk2e2NQVEYhdg3hc/66pEUDpO3IygdnrEcPWQra/ZaxLumZvZl3ZPlQbr7+OfoeAI5pFp4N51F0EGw==",
+      "version": "0.3.0-beta.1",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0-beta.1.tgz",
+      "integrity": "sha512-XfupNxc86JL3zJcAzF0UbKifgE7dsIOSUpakDlJniTya6LY0U8NIuxyadEwyHS7fidlxXveas+fcBmhnHWFmfg==",
       "dev": true,
       "dependencies": {
         "temporal-spec": "0.3.0-beta"
@@ -22476,9 +22476,9 @@
       }
     },
     "temporal-polyfill": {
-      "version": "0.3.0-beta",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0-beta.tgz",
-      "integrity": "sha512-1NJXDbRjvk2e2NQVEYhdg3hc/66pEUDpO3IygdnrEcPWQra/ZaxLumZvZl3ZPlQbr7+OfoeAI5pFp4N51F0EGw==",
+      "version": "0.3.0-beta.1",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0-beta.1.tgz",
+      "integrity": "sha512-XfupNxc86JL3zJcAzF0UbKifgE7dsIOSUpakDlJniTya6LY0U8NIuxyadEwyHS7fidlxXveas+fcBmhnHWFmfg==",
       "dev": true,
       "requires": {
         "temporal-spec": "0.3.0-beta"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "jest-extended": "^4.0.2",
         "license-checker": "^25.0.1",
-        "temporal-polyfill": "^0.3.0-beta.1",
+        "temporal-polyfill": "^0.3.0",
         "typedoc": "^0.27.2",
         "typedoc-github-wiki-theme": "^2.1.0",
         "typedoc-plugin-markdown": "^4.3.1",
@@ -12399,18 +12399,18 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.3.0-beta.1",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0-beta.1.tgz",
-      "integrity": "sha512-XfupNxc86JL3zJcAzF0UbKifgE7dsIOSUpakDlJniTya6LY0U8NIuxyadEwyHS7fidlxXveas+fcBmhnHWFmfg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0.tgz",
+      "integrity": "sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==",
       "dev": true,
       "dependencies": {
-        "temporal-spec": "0.3.0-beta"
+        "temporal-spec": "0.3.0"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "0.3.0-beta",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0-beta.tgz",
-      "integrity": "sha512-iZsNNAyOAfHjGJg8SdZD77OD3lhQW3SOh0BhXzVUKCtbxoZ5tzt5npuvbeSZW+tyOZsQCgd1766A3hfwFulOJQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0.tgz",
+      "integrity": "sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ==",
       "dev": true
     },
     "node_modules/term-size": {
@@ -22476,18 +22476,18 @@
       }
     },
     "temporal-polyfill": {
-      "version": "0.3.0-beta.1",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0-beta.1.tgz",
-      "integrity": "sha512-XfupNxc86JL3zJcAzF0UbKifgE7dsIOSUpakDlJniTya6LY0U8NIuxyadEwyHS7fidlxXveas+fcBmhnHWFmfg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0.tgz",
+      "integrity": "sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==",
       "dev": true,
       "requires": {
-        "temporal-spec": "0.3.0-beta"
+        "temporal-spec": "0.3.0"
       }
     },
     "temporal-spec": {
-      "version": "0.3.0-beta",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0-beta.tgz",
-      "integrity": "sha512-iZsNNAyOAfHjGJg8SdZD77OD3lhQW3SOh0BhXzVUKCtbxoZ5tzt5npuvbeSZW+tyOZsQCgd1766A3hfwFulOJQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0.tgz",
+      "integrity": "sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ==",
       "dev": true
     },
     "term-size": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "jest-extended": "^4.0.2",
         "license-checker": "^25.0.1",
-        "temporal-polyfill": "^0.2.5",
+        "temporal-polyfill": "^0.3.0-beta",
         "typedoc": "^0.27.2",
         "typedoc-github-wiki-theme": "^2.1.0",
         "typedoc-plugin-markdown": "^4.3.1",
@@ -29,7 +29,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "temporal-polyfill": "0.2.x"
+        "temporal-polyfill": ">= 0.2.0 < 0.4.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -12399,18 +12399,18 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.5.tgz",
-      "integrity": "sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==",
+      "version": "0.3.0-beta",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0-beta.tgz",
+      "integrity": "sha512-1NJXDbRjvk2e2NQVEYhdg3hc/66pEUDpO3IygdnrEcPWQra/ZaxLumZvZl3ZPlQbr7+OfoeAI5pFp4N51F0EGw==",
       "dev": true,
       "dependencies": {
-        "temporal-spec": "^0.2.4"
+        "temporal-spec": "0.3.0-beta"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.4.tgz",
-      "integrity": "sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==",
+      "version": "0.3.0-beta",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0-beta.tgz",
+      "integrity": "sha512-iZsNNAyOAfHjGJg8SdZD77OD3lhQW3SOh0BhXzVUKCtbxoZ5tzt5npuvbeSZW+tyOZsQCgd1766A3hfwFulOJQ==",
       "dev": true
     },
     "node_modules/term-size": {
@@ -22476,18 +22476,18 @@
       }
     },
     "temporal-polyfill": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.5.tgz",
-      "integrity": "sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==",
+      "version": "0.3.0-beta",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0-beta.tgz",
+      "integrity": "sha512-1NJXDbRjvk2e2NQVEYhdg3hc/66pEUDpO3IygdnrEcPWQra/ZaxLumZvZl3ZPlQbr7+OfoeAI5pFp4N51F0EGw==",
       "dev": true,
       "requires": {
-        "temporal-spec": "^0.2.4"
+        "temporal-spec": "0.3.0-beta"
       }
     },
     "temporal-spec": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.4.tgz",
-      "integrity": "sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==",
+      "version": "0.3.0-beta",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0-beta.tgz",
+      "integrity": "sha512-iZsNNAyOAfHjGJg8SdZD77OD3lhQW3SOh0BhXzVUKCtbxoZ5tzt5npuvbeSZW+tyOZsQCgd1766A3hfwFulOJQ==",
       "dev": true
     },
     "term-size": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "jest-extended": "^4.0.2",
     "license-checker": "^25.0.1",
-    "temporal-polyfill": "^0.3.0-beta",
+    "temporal-polyfill": "^0.3.0-beta.1",
     "typedoc": "^0.27.2",
     "typedoc-github-wiki-theme": "^2.1.0",
     "typedoc-plugin-markdown": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "jest-extended": "^4.0.2",
     "license-checker": "^25.0.1",
-    "temporal-polyfill": "^0.2.5",
+    "temporal-polyfill": "^0.3.0-beta",
     "typedoc": "^0.27.2",
     "typedoc-github-wiki-theme": "^2.1.0",
     "typedoc-plugin-markdown": "^4.3.1",
@@ -58,6 +58,6 @@
     "vitest": "^3.0.5"
   },
   "peerDependencies": {
-    "temporal-polyfill": "0.2.x"
+    "temporal-polyfill": ">= 0.2.0 < 0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "jest-extended": "^4.0.2",
     "license-checker": "^25.0.1",
-    "temporal-polyfill": "^0.3.0-beta.1",
+    "temporal-polyfill": "^0.3.0",
     "typedoc": "^0.27.2",
     "typedoc-github-wiki-theme": "^2.1.0",
     "typedoc-plugin-markdown": "^4.3.1",


### PR DESCRIPTION
## Purpose

`temporal-polyfill` v0.3.0 upgrades to the March 2025 version of Temporal spec.

## Approach and changes

- Widen the allowed version range of the `temporal-polyfill` peer dependency to include v0.3.0

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
