### PR TITLE
Add deprecation warnings when no explicit currency is passed

### DIFF
--- a/.changeset/mighty-pillows-tease.md
+++ b/.changeset/mighty-pillows-tease.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/intl': minor
+---
+
+Added deprecation warnings when no explicit currency is passed to the `formatCurrency`, `formatCurrencyToParts`, and `resolveCurrencyFormat` functions.

--- a/src/data/currencies.ts
+++ b/src/data/currencies.ts
@@ -16,6 +16,9 @@
 import type { Currency } from '../types/index.js';
 
 /**
+ * @deprecated The currencies data is outdated and will be removed in a future
+ * version.
+ *
  * An object that maps a 2 char country code to its official 3 char currency code.
  * [View all supported countries](https://github.com/sumup-oss/intl-js/blob/main/src/data/currencies.ts).
  */

--- a/src/lib/number-format/currencies.ts
+++ b/src/lib/number-format/currencies.ts
@@ -31,7 +31,22 @@ function extractCountry(locale: string): string {
   return country?.toUpperCase();
 }
 
+class DeprecationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DeprecationError';
+  }
+}
+
 function resolveCurrency(locales?: Locale | Locale[]): Currency | null {
+  if (process.env.NODE_ENV !== 'production') {
+    const deprecation = new DeprecationError(
+      '[@sumup-oss/intl] The `currency` argument will become required in a future version.',
+    );
+    // biome-ignore lint/suspicious/noConsole: Development-only warning
+    console.warn(deprecation);
+  }
+
   const inferredLocale = resolveLocale(locales);
   const localesArray =
     typeof inferredLocale === 'string' ? [inferredLocale] : inferredLocale;


### PR DESCRIPTION
## Purpose

Currently, the `formatCurrency`, `formatCurrencyToParts`, and `resolveCurrencyFormat` functions look up the currency from internal data based on the locale. This data is unreliable since the locale might not include a country and some countries have or will change currency (e.g. Croatia, Bulgaria).

Removing the currency data will reduce the package size by 1.2kb (-37%).

## Approach and changes

- Mark the `CURRENCIES` export as deprecated and log a warning during development when no explicit currency is passed to the `formatCurrency`, `formatCurrencyToParts`, and `resolveCurrencyFormat` functions

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
