### PR TITLE
Add support for formatting datetime ranges

### DIFF
--- a/.changeset/khaki-sheep-warn.md
+++ b/.changeset/khaki-sheep-warn.md
@@ -1,0 +1,14 @@
+---
+'@sumup-oss/intl': minor
+---
+
+Added support for formatting datetime ranges.
+
+```ts
+import { formatDateTimeRange } from '@sumup-oss/intl';
+
+const start = new Temporal.PlainDate(2025, 11, 1);
+const end = new Temporal.PlainDate(2025, 11, 30);
+
+formatDateTimeRange(start, end, 'de-DE'); // '01.–30.11.2025'
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ export { CURRENCIES } from './data/currencies.js';
 export {
   formatDate,
   formatDateTime,
+  formatDateTimeRange,
+  formatDateTimeRangeToParts,
   formatDateTimeToParts,
   formatTime,
   isDateTimeFormatSupported,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
   formatDateTimeRangeToParts,
   formatDateTimeToParts,
   formatTime,
+  isDateTimeFormatRangeSupported,
   isDateTimeFormatSupported,
   isDateTimeFormatToPartsSupported,
   resolveDateTimeFormat,

--- a/src/lib/date-time-format/index.ts
+++ b/src/lib/date-time-format/index.ts
@@ -29,7 +29,11 @@ import {
   isDateTimeStyleSupported,
 } from './intl.js';
 
-export { isDateTimeFormatSupported, isDateTimeFormatToPartsSupported };
+export {
+  isDateTimeFormatSupported,
+  isDateTimeFormatToPartsSupported,
+  isDateTimeFormatRangeSupported,
+};
 
 /**
  * Formats a datetime with support for various

--- a/src/lib/date-time-format/index.ts
+++ b/src/lib/date-time-format/index.ts
@@ -31,16 +31,16 @@ import {
 export { isDateTimeFormatSupported, isDateTimeFormatToPartsSupported };
 
 /**
- * Formats a `Date` with support for various
+ * Formats a datetime with support for various
  * [date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#datestyle)
  * and [time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#timestyle) styles.
  *
  * @example
  * import { formatDateTime } from '@sumup-oss/intl';
  *
- * formatDateTime(new Date(2000, 1, 1), 'de-DE'); // '1.2.2000'
- * formatDateTime(new Date(2000, 1, 1), ['ban', 'id']); // '1/2/2000'
- * formatDateTime(new Date(2000, 1, 1, 12, 30), 'en-GB', {
+ * formatDateTime(new Temporal.PlainDate(2000, 2, 1), 'de-DE'); // '1.2.2000'
+ * formatDateTime(new Temporal.PlainDate(2000, 2, 1), ['ban', 'id']); // '1/2/2000'
+ * formatDateTime(new Temporal.PlainDate(2000, 2, 1, 12, 30), 'en-GB', {
  *   year: 'numeric',
  *   month: 'short',
  *   day: 'numeric',
@@ -49,7 +49,7 @@ export { isDateTimeFormatSupported, isDateTimeFormatToPartsSupported };
  * }); // 1 Feb 2000, 12:30
  *
  * @remarks
- * In runtimes that don't support the `Intl.DateTimeFormat` API, the date is
+ * In runtimes that don't support the `Intl.DateTimeFormat` API, the datetime is
  * formatted using the `Date.toLocale(Date|Time)String` API.
  *
  * In runtimes that don't support the `dateStyle` and `timeStyle` options, the
@@ -60,13 +60,13 @@ export { isDateTimeFormatSupported, isDateTimeFormatToPartsSupported };
 export const formatDateTime = formatDateTimeFactory();
 
 /**
- * Formats a `Date` with support for various
+ * Formats a date with support for various
  * [date styles](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#datestyle).
  *
  * @example
  * import { formatDate } from '@sumup-oss/intl';
  *
- * const date = new Date(2000, 1, 1);
+ * const date = new Temporal.PlainDate(2000, 2, 1);
  * const locale = 'en-GB';
  *
  * formatDate(date, locale, 'short'); // '01/02/2000'
@@ -92,22 +92,22 @@ export function formatDate(
 }
 
 /**
- * Formats a `Date` with support for various
+ * Formats a time with support for various
  * [time styles](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#datestyle).
  *
  * @example
  * import { formatTime } from '@sumup-oss/intl';
  *
- * const time = new Date(2000, 1, 1, 9, 55);
+ * const time = new Temporal.PlainTime(9, 55);
  * const locale = 'en-GB';
  *
  * formatTime(time, locale, 'short'); // '09:55'
  * formatTime(time, locale, 'medium'); // '09:55:00'
- * formatTime(time, locale, 'long'); // '09:55:00 CET'
- * formatTime(time, locale, 'full'); // '09:55:00 Central European Standard Time'
+ * formatTime(time, locale, 'long'); // '09:55:00 UTC'
+ * formatTime(time, locale, 'full'); // '09:55:00 Coordinated Universal Time'
  *
  * @remarks
- * In runtimes that don't support the `Intl.DateTimeFormat` API, the date is
+ * In runtimes that don't support the `Intl.DateTimeFormat` API, the time is
  * formatted using the `Date.toLocale(Date|Time)String` API.
  *
  * In runtimes that don't support the `timeStyle` option, the styles are
@@ -218,7 +218,7 @@ function formatDateTimeToPartsFactory(): (
 ) => (Intl.DateTimeFormatPart | { type: 'date'; value: string })[] {
   if (!isDateTimeFormatToPartsSupported) {
     return (date, locales, options) => {
-      // In runtimes that don't support formatting to parts, the date is
+      // In runtimes that don't support formatting to parts, the datetime is
       // localized and returned as a single string literal part.
       const value = formatDateTime(date, locales, options);
       return [{ type: 'literal', value }];
@@ -233,7 +233,7 @@ function formatDateTimeToPartsFactory(): (
 }
 
 /**
- * Resolves the locale and collation options that are used to format a `Date`.
+ * Resolves the locale and collation options that are used to format a datetime.
  *
  * @example
  * import { resolveDateTimeFormat } from '@sumup-oss/intl';

--- a/src/lib/date-time-format/intl.ts
+++ b/src/lib/date-time-format/intl.ts
@@ -45,6 +45,19 @@ export const isDateTimeFormatToPartsSupported = (() => {
 })();
 
 /**
+ * Whether the `Intl`, `Intl.DateTimeFormat`, and
+ * `Intl.DateTimeFormat.formatRange` APIs are supported by the runtime.
+ */
+export const isDateTimeFormatRangeSupported = (() => {
+  try {
+    // @ts-expect-error
+    return typeof Intl.DateTimeFormat.prototype.formatRange !== 'undefined';
+  } catch (_error) {
+    return false;
+  }
+})();
+
+/**
  * Whether the `dateStyle` and `timeStyle` DateTimeFormat options
  * are supported by the runtime.
  */

--- a/src/lib/date-time-format/tests/format-range-to-parts.spec.ts
+++ b/src/lib/date-time-format/tests/format-range-to-parts.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// biome-ignore lint/suspicious/noShadowRestrictedNames: Necessary for the polyfill to work
+import { Intl, Temporal } from 'temporal-polyfill';
+import { describe, expect, it } from 'vitest';
+
+import { formatDateTimeRangeToParts } from '../index.js';
+
+import { locales } from './shared.js';
+
+describe('Dates & times', () => {
+  describe('formatDateTimeRangeToParts', () => {
+    it('should format a datetime range', () => {
+      const locale = locales[0];
+      const startDate = new Temporal.PlainDate(2024, 1, 1);
+      const endDate = new Temporal.PlainDate(2024, 2, 1);
+      const actual = formatDateTimeRangeToParts(startDate, endDate, locale);
+      expect(actual).toEqual([
+        {
+          'source': 'startRange',
+          'type': 'day',
+          'value': '01',
+        },
+        {
+          'source': 'startRange',
+          'type': 'literal',
+          'value': '.',
+        },
+        {
+          'source': 'startRange',
+          'type': 'month',
+          'value': '01',
+        },
+        {
+          'source': 'shared',
+          'type': 'literal',
+          'value': '. – ',
+        },
+        {
+          'source': 'endRange',
+          'type': 'day',
+          'value': '01',
+        },
+        {
+          'source': 'endRange',
+          'type': 'literal',
+          'value': '.',
+        },
+        {
+          'source': 'endRange',
+          'type': 'month',
+          'value': '02',
+        },
+        {
+          'source': 'shared',
+          'type': 'literal',
+          'value': '.',
+        },
+        {
+          'source': 'shared',
+          'type': 'year',
+          'value': '2024',
+        },
+      ]);
+    });
+
+    it.each(locales)('should format a date time range for %o', (locale) => {
+      const startDate = new Temporal.PlainDate(2024, 1, 1);
+      const endDate = new Temporal.PlainDate(2024, 2, 1);
+      const actual = formatDateTimeRangeToParts(startDate, endDate, locale);
+      expect(actual).toBeArray();
+      expect(Intl.DateTimeFormat).toHaveBeenCalledWith(locale, undefined);
+    });
+  });
+});

--- a/src/lib/date-time-format/tests/format-range.spec.ts
+++ b/src/lib/date-time-format/tests/format-range.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// biome-ignore lint/suspicious/noShadowRestrictedNames: Necessary for the polyfill to work
+import { Intl, Temporal } from 'temporal-polyfill';
+import { describe, expect, it } from 'vitest';
+
+import { formatDateTimeRange } from '../index.js';
+
+import { locales } from './shared.js';
+
+describe('Dates & times', () => {
+  describe('formatDateTimeRange', () => {
+    it('should format a datetime range', () => {
+      const locale = locales[0];
+      const startDate = new Temporal.PlainDate(2024, 1, 1);
+      const endDate = new Temporal.PlainDate(2024, 2, 1);
+      const actual = formatDateTimeRange(startDate, endDate, locale);
+      expect(actual).toBe('01.01. – 01.02.2024');
+    });
+
+    it.each(locales)('should format a date time range for %o', (locale) => {
+      const startDate = new Temporal.PlainDate(2024, 1, 1);
+      const endDate = new Temporal.PlainDate(2024, 2, 1);
+      const actual = formatDateTimeRange(startDate, endDate, locale);
+      expect(actual).toBeString();
+      expect(Intl.DateTimeFormat).toHaveBeenCalledWith(locale, undefined);
+    });
+  });
+});

--- a/src/lib/date-time-format/tests/format-range.spec.ts
+++ b/src/lib/date-time-format/tests/format-range.spec.ts
@@ -25,10 +25,20 @@ describe('Dates & times', () => {
   describe('formatDateTimeRange', () => {
     it('should format a datetime range', () => {
       const locale = locales[0];
-      const startDate = new Temporal.PlainDate(2024, 1, 1);
-      const endDate = new Temporal.PlainDate(2024, 2, 1);
-      const actual = formatDateTimeRange(startDate, endDate, locale);
+      const start = new Temporal.PlainDate(2024, 1, 1);
+      const end = new Temporal.PlainDate(2024, 2, 1);
+      const actual = formatDateTimeRange(start, end, locale);
       expect(actual).toBe('01.01. – 01.02.2024');
+    });
+
+    it('should format a time range', () => {
+      const locale = locales[1];
+      const start = new Temporal.PlainTime(11, 30);
+      const end = new Temporal.PlainTime(12, 45);
+      const actual = formatDateTimeRange(start, end, locale, {
+        timeStyle: 'short',
+      });
+      expect(actual).toBe('11:30 a.m. – 12:45 p.m.');
     });
 
     it.each(locales)('should format a date time range for %o', (locale) => {

--- a/src/lib/date-time-format/tests/unsupported-intl-api.spec.ts
+++ b/src/lib/date-time-format/tests/unsupported-intl-api.spec.ts
@@ -13,10 +13,13 @@
  * limitations under the License.
  */
 
+import { Temporal } from 'temporal-polyfill';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
   formatDateTime,
+  formatDateTimeRange,
+  formatDateTimeRangeToParts,
   formatDateTimeToParts,
   resolveDateTimeFormat,
 } from '../index.js';
@@ -29,6 +32,7 @@ vi.mock('../intl', async () => {
     ...intl,
     isDateTimeFormatSupported: false,
     isDateTimeFormatToPartsSupported: false,
+    isDateTimeFormatRangeSupported: false,
   };
 });
 
@@ -52,6 +56,33 @@ describe('Dates & times', () => {
         timeStyle: 'short',
       });
       expect(actual).toMatchSnapshot();
+    });
+
+    it('should format a datetime range', () => {
+      const startDate = new Temporal.PlainDate(2024, 1, 1, 'gregory');
+      const endDate = new Temporal.PlainDate(2024, 2, 1, 'gregory');
+      const actual = formatDateTimeRange(startDate, endDate, locale);
+      expect(actual).toBe('1/1/2024 – 2/1/2024');
+    });
+
+    it('should format a datetime range to parts', () => {
+      const startDate = new Temporal.PlainDate(2024, 1, 1, 'gregory');
+      const endDate = new Temporal.PlainDate(2024, 2, 1, 'gregory');
+      const actual = formatDateTimeRangeToParts(startDate, endDate, locale);
+      expect(actual).toEqual([
+        {
+          'type': 'literal',
+          'value': '1/1/2024',
+        },
+        {
+          'type': 'literal',
+          'value': ' – ',
+        },
+        {
+          'type': 'literal',
+          'value': '2/1/2024',
+        },
+      ]);
     });
 
     it('should format a date time to a single literal part', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2017",
     "module": "NodeNext",
-    "lib": ["es2020", "es2017", "es7", "es6", "dom"],
+    "lib": ["es2020", "es2019", "es2018", "es2017", "es7", "es6", "dom"],
     "declaration": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Purpose

The [`Intl.DateTimeFormat.formatRange`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRange) method enables language-sensitive relative formatting of datetime ranges, e.g. "01.–30.11.2025" or "11:30 a.m. – 12:45 p.m.". It's [widely supported in browsers](https://caniuse.com/mdn-javascript_builtins_intl_numberformat_formatrange), with only Safari lagging behind.

## Approach and changes

- Added `formatDateTimeRange`, `formatDateTimeRangeToParts`, and `isDateTimeFormatRangeSupported` 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
