### PR TITLE
Hard-code decimal places for COP and HUF

### DIFF
--- a/.changeset/proud-shrimps-exist.md
+++ b/.changeset/proud-shrimps-exist.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/intl': minor
+---
+
+Hard-coded the maximum fraction digits for Colombian pesos (COP) and Hungarian forint (HUF) to ensure consistency between computer systems which strictly follow ISO 4217 (Node, Firefox, Safari) and those that don't (Chrome). Even though these currencies don't use decimal values in everyday life, ISO 4217 defines the number of decimal places as 2.

--- a/src/data/currencies.ts
+++ b/src/data/currencies.ts
@@ -518,7 +518,7 @@ export const CURRENCIES: { [country: string]: Currency } = {
 };
 
 /**
- * An array of currencies that support decimals according to the ISO standard
+ * An array of currencies that support decimals according to ISO 4217
  * but don't use decimals in everyday life.
  */
 export const CURRENCIES_WITHOUT_DECIMALS = ['COP', 'HUF'];

--- a/src/lib/number-format/currencies.ts
+++ b/src/lib/number-format/currencies.ts
@@ -95,12 +95,17 @@ export function getCurrencyOptions(
     };
   }
 
+  // Some currencies support decimals according to ISO 4217 but don't use them
+  // in everyday life. In order to ensure consistency between computer systems
+  // which strictly follow ISO 4217 (Node, Firefox, Safari) and those that don't
+  // (Chrome), we hard-code the minimum and maximum fraction digits.
   if (CURRENCIES_WITHOUT_DECIMALS.includes(finalCurrency)) {
     return {
       ...options,
       style: 'currency',
       currency: finalCurrency,
       minimumFractionDigits: 0,
+      maximumFractionDigits: 2,
     };
   }
 


### PR DESCRIPTION
## Purpose

Chrome appears to have recently updated the maximum fraction digits for Colombian pesos and Hungarian forint (HUF), breaking with [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html). Even though these currencies don't use decimal values in everyday life, ISO 4217 defines the number of decimal places as 2.

## Approach and changes

- Hard-code the maximum fraction digits for Colombian pesos (COP) and Hungarian forint (HUF) to ensure consistency between computer systems which strictly follow ISO 4217 (Node, Firefox, Safari) and those that don't (Chrome).

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
